### PR TITLE
define _GNU_SOURCE if not yet defined

### DIFF
--- a/cdl.h
+++ b/cdl.h
@@ -53,7 +53,9 @@
 #ifndef CDL_H
 #define CDL_H
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 /* Global includes */
 #include <stdio.h>


### PR DESCRIPTION
`nvcc` says
```
In file included from ./foobar.cpp:14:
./cdl86/cdl.h:56: warning: "_GNU_SOURCE" redefined
   56 | #define _GNU_SOURCE
      |
<command-line>: note: this is the location of the previous definition
```
if `cdl.h` is included. It may be because `nvcc` has two compilation phases: host code and device code.

Therefore, I modified `cdl.h` to define `_GNU_SOURCE` if it is not yet defined.